### PR TITLE
Return overlapped nodes in-order

### DIFF
--- a/src/com/brein/time/timeintervals/indexes/IntervalTree.java
+++ b/src/com/brein/time/timeintervals/indexes/IntervalTree.java
@@ -118,7 +118,7 @@ public class IntervalTree implements Collection<IInterval>, Externalizable {
 
         rightNodeStream = this._overlap(node.getRight(), query);
 
-        return Stream.of(nodeStream, leftNodeStream, rightNodeStream).flatMap(s -> s);
+        return Stream.of(leftNodeStream, nodeStream, rightNodeStream).flatMap(s -> s);
     }
 
     public IntervalTree insert(final IInterval interval) {


### PR DESCRIPTION
Switch from pre-order traversal to in-order to get overlapped nodes in order of their comparator.